### PR TITLE
Fixed random crash when operating on Gtk.Listview

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ import (
 	"github.com/gotk3/gotk3/gtk"
 )
 
-const version = "0.0.2"
+const version = "0.1.0"
 
 type WindowState int
 

--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ var (
 	monitors                           []monitor
 	clients                            []client
 	activeClient                       *client
+	lastWinAddr                        string
 )
 
 // Flags
@@ -627,12 +628,17 @@ func main() {
 				fmt.Println("Error reading from socket2:", err)
 			}
 
-			if strings.Contains(string(buf[:n]), "activewindowv2") {
-				err = listClients()
-				if err != nil {
-					log.Fatalf("Couldn't list clients: %s", err)
-				} else {
-					refreshMainBox(true)
+			s := string(buf[:n])
+			if strings.Contains(s, "activewindowv2") {
+				winAddr := strings.TrimSpace(strings.Split(s, "activewindowv2>>")[1])
+				if winAddr != lastWinAddr && !strings.Contains(winAddr, ">>") {
+					err = listClients()
+					if err != nil {
+						log.Fatalf("Couldn't list clients: %s", err)
+					} else {
+						refreshMainBox(true)
+					}
+					lastWinAddr = winAddr
 				}
 			}
 		}


### PR DESCRIPTION
As moving the cursor over Gtk/ListView triggers Hyprland `activewindow` events one by one in massive amounts (for the very same window!), we used to end up in random GTK crashes. From now on we check if the event was triggered by another window before listing clients again. This should protect the dock from crashing on the random basis.