### PR TITLE
fix missing icon when window class has space

### DIFF
--- a/tools.go
+++ b/tools.go
@@ -504,6 +504,7 @@ func isIn(slice []string, val string) bool {
 }
 
 func getIcon(appName string) (string, error) {
+	appName = strings.Split(appName, " ")[0]
 	if strings.HasPrefix(strings.ToUpper(appName), "GIMP") {
 		return "gimp", nil
 	}


### PR DESCRIPTION
this fixes an issue where an application's icon did not show up, and left a smaller empty image in its place
`hyprctl clients` shows the window, with class/initialClass `google-chrome (/path/to/profile)`

since that won't resolve to an icon correctly, lets use first word only

seems to work with other applications just fine.

maybe related to #4 

(in my case, it can also be solved using chromium flag `--class=some-class` but that creates additional issues, such as window-grouping, elsewhere.)
