### PR TITLE
Added (very basic) functionality to handle special workspaces

### DIFF
--- a/tools.go
+++ b/tools.go
@@ -151,6 +151,9 @@ func taskButton(t client, instances []client) *gtk.Box {
 			if btnEvent.Type() == gdk.EVENT_BUTTON_RELEASE || btnEvent.Type() == gdk.EVENT_TOUCH_END {
 				if btnEvent.Button() == 1 || btnEvent.Type() == gdk.EVENT_TOUCH_END {
 					cmd := fmt.Sprintf("dispatch focuswindow address:%s", t.Address)
+					if strings.HasPrefix(t.Workspace.Name, "special:") {
+						cmd = fmt.Sprintf("dispatch togglespecialworkspace %s", strings.Split(t.Workspace.Name, ":")[1])
+					}
 					reply, _ := hyprctl(cmd)
 					log.Debugf("%s -> %s", cmd, reply)
 					return true

--- a/tools.go
+++ b/tools.go
@@ -151,8 +151,9 @@ func taskButton(t client, instances []client) *gtk.Box {
 			if btnEvent.Type() == gdk.EVENT_BUTTON_RELEASE || btnEvent.Type() == gdk.EVENT_TOUCH_END {
 				if btnEvent.Button() == 1 || btnEvent.Type() == gdk.EVENT_TOUCH_END {
 					cmd := fmt.Sprintf("dispatch focuswindow address:%s", t.Address)
-					if strings.HasPrefix(t.Workspace.Name, "special:") {
-						cmd = fmt.Sprintf("dispatch togglespecialworkspace %s", strings.Split(t.Workspace.Name, ":")[1])
+					if strings.HasPrefix(t.Workspace.Name, "special") {
+						_, specialName, _ := strings.Cut(t.Workspace.Name, "special:")
+						cmd = fmt.Sprintf("dispatch togglespecialworkspace %s", specialName)
 					}
 					reply, _ := hyprctl(cmd)
 					log.Debugf("%s -> %s", cmd, reply)
@@ -207,6 +208,10 @@ func clientMenu(class string, instances []client) gtk.Menu {
 		a := instance.Address
 		menuItem.Connect("activate", func() {
 			cmd := fmt.Sprintf("dispatch focuswindow address:%s", a)
+			if strings.HasPrefix(instance.Workspace.Name, "special") {
+				_, specialName, _ := strings.Cut(instance.Workspace.Name, "special:")
+				cmd = fmt.Sprintf("dispatch togglespecialworkspace %s", specialName)
+			}
 			reply, _ := hyprctl(cmd)
 			log.Debugf("%s -> %s", cmd, reply)
 		})


### PR DESCRIPTION
Hi :)
Currently, windows residing in a [special workspace](https://wiki.hyprland.org/Configuring/Dispatchers/#special-workspace) will be treated by nwg-dock just like any other window, triggering `focuswindow`. This does not work of course.

What I did at the moment is simply to actually dispatch `togglespecialworkspace`. Now when we click on a client icon residing in a special workspace, the client will be moved in and out of the special workspace (it won't be focused), together with whatever else might be in the special workspace. This works well, I guess, for users that will only put one and only one client in a special workspace. 

That said, I know that this is probably not ready for merging, but I'm still opening this pull request for discussion.