### PR TITLE
Set Layer Namespace

### DIFF
--- a/main.go
+++ b/main.go
@@ -230,6 +230,7 @@ func setupHotSpot(monitor gdk.Monitor, dockWindow *gtk.Window) gtk.Window {
 
 	layershell.InitForWindow(win)
 	layershell.SetMonitor(win, &monitor)
+	layershell.SetNamespace(win, "nwg-dock")
 
 	var box *gtk.Box
 	if *position == "bottom" || *position == "top" {


### PR DESCRIPTION
This is useful for uniquely identifying the layer used by `nwg-dock`, as by default the layer name is set to `gtk-layer-shell`, which is the same as many other apps (like wlogout), because of which specific layer rules cannot be set by [`layerrule`](https://wiki.hyprland.org/Configuring/Window-Rules/#layer-rules) for Hyprland