### PR TITLE
Maintain order of icons on the dock

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"syscall"
@@ -103,6 +104,15 @@ func buildMainBox(vbox *gtk.Box) {
 			allItems = append(allItems, cntPin)
 		}
 	}
+
+	sort.Slice(clients, func(i, j int) bool {
+		if clients[i].Workspace.Id != clients[j].Workspace.Id {
+			return clients[i].Workspace.Id < clients[j].Workspace.Id
+		} else {
+			return clients[i].Class < clients[j].Class
+		}
+	})
+
 	for _, cntTask := range clients {
 		if !isIn(allItems, cntTask.Class) && !strings.Contains(*launcherCmd, cntTask.Class) && cntTask.Class != "" {
 			allItems = append(allItems, cntTask.Class)


### PR DESCRIPTION
In relation to [this issue](https://github.com/nwg-piotr/nwg-dock-hyprland/issues/44).
I tested it and it works.
Sorts first by workspace and then by class if necessary.