### PR TITLE
Update module name to conform 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module nwg-dock-hyprland
+module github.com/nwg-piotr/nwg-dock-hyprland
 
 go 1.23
 


### PR DESCRIPTION
Fedora requires the module name to follow this convention of having the domain. Therefore I just changed that so it builds successfully.

Info: https://bugzilla.redhat.com/show_bug.cgi?id=2323149

Once this is merged, it will likely be approved.