### PR TITLE
fix: adjust tooltip parsing

### DIFF
--- a/tools.go
+++ b/tools.go
@@ -804,7 +804,7 @@ func getName(appName string) string {
 				return name
 			}
 			for _, line := range lines {
-				if strings.HasPrefix(strings.ToUpper(line), "NAME") {
+				if strings.HasPrefix(strings.ToUpper(line), "NAME=") {
 					name = line[5:]
 					break
 				}


### PR DESCRIPTION
very small change, but some of the desktop files from programs list other languages Names before the initial one, e.g.
this is my installed thunar desktop file:
```
[Desktop Entry]
Name[am]=ቱናር መዝገብ አስተዳዳሪ
Name[ar]=مدير الملفات تونار
Name[ast]=Alministrador de ficheros Thunar
...
Name=Thunar File Manager
```

with the current parsing the tooltip when I hover over thunar is 'am]=ቱናር መዝገብ አስተዳዳሪ'
there are a few other programs I've noticed that have other languages translations before the default Name=, and this little change shouldn't do anything else but fix tooltips for these desktop files that are ordered different

(I guess ideally the localization should be figured out and then the appropriate language option should be displayed, but this should at least be more likely to provide a solid default)