### PR TITLE
Update tools.go - removing "sh -c" wrapper from started processes

### DIFF
--- a/tools.go
+++ b/tools.go
@@ -978,7 +978,7 @@ func listGdkMonitors() ([]gdk.Monitor, error) {
 
 // Returns output of a CLI command with optional arguments
 func getCommandOutput(command string) string {
-	out, err := exec.Command("sh", "-c", command).Output()
+	out, err := exec.Command("env", "-S", command).Output()
 	if err != nil {
 		return ""
 	}


### PR DESCRIPTION
Replacing "sh -c" with "env -S" as happened in nwg-drawer, thus removing the unnecesarry "sh -c" wrapper but also keeping the env.