### PR TITLE
feat: search missing .desktop file by startupWMClass

### DIFF
--- a/tools.go
+++ b/tools.go
@@ -734,6 +734,23 @@ func searchDesktopDirs(badAppID string) string {
 				return filepath.Join(d, item.Name())
 			}
 		}
+
+		for _, item := range items {
+			if item.IsDir() {
+				continue
+			}
+
+			p := filepath.Join(d, item.Name())
+			lines, err := readTextFile(p)
+
+			if err != nil {
+				log.Warn(err)
+			} else {
+				if strings.Contains(lines, "StartupWMClass="+b4Separator) {
+					return filepath.Join(d, item.Name())
+				}
+			}
+		}
 	}
 	return ""
 }


### PR DESCRIPTION
Hello,

this pr adds another fallback for missing icons, which is looking for a matching StartupWMClass in .desktop files(https://specifications.freedesktop.org/desktop-entry-spec/latest/recognized-keys.html) with the app class, which at least I know nixos sometimes uses to "patch" desktop files with proper classes, until it is properly addressed upstream or similiar: https://github.com/search?q=repo%3ANixOS%2Fnixpkgs+StartupWMClass&type=code

for example, virt manager on nixos at least has the class '.virt-manager-wrapped', which is added to the desktop file as startupclass in the nix package, and this pr now allows me to have an icon for virt manager