### PR TITLE
feat: add hotspot layer config option

### DIFF
--- a/main.go
+++ b/main.go
@@ -72,6 +72,7 @@ var exclusive = flag.Bool("x", false, "set eXclusive zone: move other windows as
 var full = flag.Bool("f", false, "take Full screen width/height")
 var ignoreClasses = flag.String("g", "", "quote-delimited, space-separated class list to iGnore in the dock")
 var hotspotDelay = flag.Int64("hd", 20, "Hotspot Delay [ms]; the smaller, the faster mouse pointer needs to enter hotspot for the dock to appear; set 0 to disable")
+var hotspotLayer = flag.String("hl", "overlay", "Hotspot Layer \"overlay\" or \"top\"")
 var ico = flag.String("ico", "", "alternative name or path for the launcher ICOn")
 var ignoreWorkspaces = flag.String("iw", "", "Ignore the running applications on these Workspaces based on the workspace's name or id, e.g. \"special,10\"")
 var imgSize = flag.Int("i", 48, "Icon size")
@@ -321,7 +322,11 @@ func setupHotSpot(monitor gdk.Monitor, dockWindow *gtk.Window) gtk.Window {
 		gtklayershell.SetAnchor(win, gtklayershell.LayerShellEdgeBottom, *full)
 	}
 
-	gtklayershell.SetLayer(win, gtklayershell.LayerShellLayerOverlay)
+	if *hotspotLayer == "top" {
+		gtklayershell.SetLayer(win, gtklayershell.LayerShellLayerTop)
+	} else {
+		gtklayershell.SetLayer(win, gtklayershell.LayerShellLayerOverlay)
+	}
 
 	// resolve #65
 	// gtklayershell.SetMargin(win, gtklayershell.LayerShellEdgeTop, *marginTop)


### PR DESCRIPTION
This just adds the option to specify the layer for the hotspot,
I had a bug where programs in fullscreen didn't allow me to click on the very bottom part of their app when I used the autohide feature, and I figured out it's because the hotspot is set to `overlay`, so it was on top of my fullscreen window and absorbed my mouse clicks

I'm not sure if putting it to the top layer by default would break anything else, so I didn't change the current behavior and added a config option, but it does seem to work better for me