### PR TITLE
fix: reap child processes in launch() to prevent zombies

### DIFF
--- a/tools.go
+++ b/tools.go
@@ -960,6 +960,8 @@ func launch(ID string) {
 
 	if err := cmd.Start(); err != nil {
 		log.Error("Unable to launch command!", err.Error())
+	} else {
+		go cmd.Wait() // Reap child process to prevent zombie
 	}
 
 	if *autohide {


### PR DESCRIPTION
## Problem

The `launch()` function in `tools.go` calls `cmd.Start()` without ever calling `cmd.Wait()`. This means when a launched application exits, the kernel keeps its process table entry waiting for the parent (the dock) to collect the exit status. Since the dock never does, the child becomes a zombie (defunct) process.

Every application launched from the dock and then closed leaves behind a zombie. Over time these accumulate silently. While zombies don't consume CPU or memory, they occupy PID table entries and can cause side effects — for example, applications like Chrome that use lock files may fail to start if a previous zombie is still lingering.

Reproduced on Fedora 43 + Hyprland, nwg-dock-hyprland v0.4.8:

```
$ ps aux | grep defunct
user  2135323  0.0  0.0  0  0 ?  ZN  01:56  0:00 [chrome] <defunct>
user  2135548  0.0  0.0  0  0 ?  ZN  01:56  0:00 [chrome] <defunct>
... (14 zombie chrome processes after normal usage)
```

## Fix

Add `go cmd.Wait()` after a successful `cmd.Start()`. The goroutine waits for the child process to exit and reaps it, without blocking the dock's main thread.

This is consistent with how the launcher button handler in the same file already works (line 136-141), which uses `cmd.Run()` (equivalent to `Start()` + `Wait()`) inside a goroutine.