### PR TITLE
fix: fallback to legacy dispatch on invalid dispatcher

### DIFF
--- a/hypr.go
+++ b/hypr.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -126,8 +127,8 @@ func getActiveWindow() (*client, error) {
 func dispatch(luaCmd string, legacyCmd string) {
 	reply, err := hyprctl(luaCmd)
 
-	// Fall back to legacy
-	if err != nil {
+	// Fall back to legacy if connection error or invalid dispatcher
+	if err != nil || strings.Contains(string(reply), "Invalid dispatcher") {
 		reply, err = hyprctl(legacyCmd)
 	}
 


### PR DESCRIPTION
## Summary

- The `dispatch()` function only falls back to legacy commands on connection errors
- Hyprland versions that don't support lua dispatchers (e.g., 0.55.2) return `"Invalid dispatcher"` as a successful response, so the fallback never triggers
- This causes dock icon clicks to silently fail (no window focus/switch)
- Fix: also check the reply content for `"Invalid dispatcher"` before falling back to legacy commands

## Test plan

- [x] Tested on Hyprland 0.55.2 — dock icon click now correctly focuses windows using legacy `focuswindow` dispatch
- [x] Legacy dispatch commands (`closewindow`, `togglefloating`, `fullscreen`, `movetoworkspace`) should also work via the same fallback path

🤖 Generated with [Claude Code](https://claude.com/claude-code)