### PR TITLE
Adding support for hyprland-virtual-desktops plugin

### DIFF
--- a/hypr.go
+++ b/hypr.go
@@ -19,6 +19,32 @@ type workspace struct {
 	Lastwindowtitle string `json:"lastwindowtitle"`
 }
 
+type hyprPlugin struct {
+	Name string `json:"name"`
+}
+
+type vDesk struct {
+	Id         int    `json:"id"`
+	Name       string `json:"name"`
+	Workspaces []int  `json:"workspaces"`
+}
+
+func isPluginLoaded(plugin string) bool {
+	reply, err := hyprctl("j/plugin list")
+	if err == nil {
+		var plugins []hyprPlugin
+		err = json.Unmarshal([]byte(reply), &plugins)
+		if err == nil {
+			for _, p := range plugins {
+				if p.Name == plugin {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
 type monitor struct {
 	Id              int     `json:"id"`
 	Name            string  `json:"name"`
@@ -139,6 +165,34 @@ func dispatch(luaCmd string, legacyCmd string) {
 }
 
 func focusWindow(address string) {
+	if isPluginLoaded("virtual-desktops") {
+		reply, err := hyprctl("j/printstate")
+		if err == nil {
+			var vdesks []vDesk
+			json.Unmarshal([]byte(reply), &vdesks)
+
+			var wsId = -1
+			for _, c := range clients {
+				if c.Address == address {
+					wsId = c.Workspace.Id
+					break
+				}
+			}
+			if wsId != -1 {
+				for _, vd := range vdesks {
+					for _, ws := range vd.Workspaces {
+						if ws == wsId {
+							luaCmd := fmt.Sprintf("dispatch function() hl.plugin.virtual_desktops.vdesk('%d') end", vd.Id)
+							legacyCmd := fmt.Sprintf("dispatch vdesk %d", vd.Id)
+							dispatch(luaCmd, legacyCmd)
+							break
+						}
+					}
+				}
+			}
+		}
+	}
+
 	lua := fmt.Sprintf("dispatch hl.dsp.focus({ window = 'address:%s' })", address)
 	legacy := fmt.Sprintf("dispatch focuswindow address:%s ", address)
 	dispatch(lua, legacy)
@@ -165,5 +219,11 @@ func toggleFullscreenWindow(address string) {
 func moveWindowToWorkspace(address string, workspace int) {
 	lua := fmt.Sprintf("dispatch hl.dsp.window.move({ workspace = '%v', window = 'address:%v' })", workspace, address)
 	legacy := fmt.Sprintf("dispatch movetoworkspace %d, address:%s", workspace, address)
+	dispatch(lua, legacy)
+}
+
+func moveWindowToDesk(address string, desk int) {
+	lua := fmt.Sprintf("dispatch function() hl.plugin.virtual_desktops.movetodesk('%d,address:%s') end", desk, address)
+	legacy := fmt.Sprintf("dispatch movetodesk %d,address:%s", desk, address)
 	dispatch(lua, legacy)
 }

--- a/tools.go
+++ b/tools.go
@@ -329,6 +329,7 @@ func clientMenu(class string, instances []client) gtk.Menu {
 
 func clientMenuContext(class string, instances []client) gtk.Menu {
 	menu := gtk.NewMenu()
+	virtualDesktopsLoaded := isPluginLoaded("virtual-desktops")
 
 	iconName, err := getIcon(class)
 	if err != nil {
@@ -377,10 +378,19 @@ func clientMenuContext(class string, instances []client) gtk.Menu {
 		submenu.Append(&s.MenuItem)
 
 		for i := 1; i < int(*numWS)+1; i++ {
-			subItem := gtk.NewMenuItemWithLabel(fmt.Sprintf("-> WS %v", i))
+			label := fmt.Sprintf("-> WS %v", i)
+			if virtualDesktopsLoaded {
+				label = fmt.Sprintf("-> VD %v", i)
+			}
+			
+			subItem := gtk.NewMenuItemWithLabel(label)
 			target := i
 			subItem.Connect("activate", func() {
-				moveWindowToWorkspace(a, target)
+				if virtualDesktopsLoaded {
+					moveWindowToDesk(a, target)
+				} else {
+					moveWindowToWorkspace(a, target)
+				}
 			})
 			submenu.Append(subItem)
 		}


### PR DESCRIPTION
This PR adds support for this specific plugin.

The hyprland-virtual-desktops plugin essentially considers groups of workspaces units called virtual desks (or vdesks for short), so if we click an icon for an app already open, focusWindow will essentially tell hyprland "Change the workspace to the target workspace where the window lives, on whatever monitor that window is"

This means if you have 3 monitors and vdesks 1-4, you have:
- vdesk1 : ws1, ws2, ws3
- vdesk2 : ws4, ws5, ws6

and so on, but if we're on vdesk2, and we click on an app that is open on vdesk3 on the right monitor (ws9), only that workspace is switched, so now, vdesk2 is ws4, ws5, **ws9**, which is incorrect.

This PR basically detects if the plugin is loaded, and if so, instead of calling focuswindow, we first switch to the target vdesk, and then focus window. Avoiding messing up the workspaces assigned to the virtual desks

Furthermore, I also made it so the "-> WS 1" actions are changed to "-> VD 1" and calling the appropriate dispatchers

Tested working